### PR TITLE
Add Codex review trigger workflow after green PR CI

### DIFF
--- a/.github/workflows/codex_review_trigger.yml
+++ b/.github/workflows/codex_review_trigger.yml
@@ -35,8 +35,8 @@ jobs:
             let headSha;
 
             if (context.eventName === 'workflow_dispatch') {
-              prNumber = Number(core.getInput('pr_number'));
-              headSha = core.getInput('head_sha')?.trim();
+              prNumber = Number(context.payload.inputs?.pr_number);
+              headSha = context.payload.inputs?.head_sha?.trim();
               if (!prNumber || !headSha) {
                 core.setFailed('workflow_dispatch requires both inputs: pr_number and head_sha');
                 return;

--- a/.github/workflows/codex_review_trigger.yml
+++ b/.github/workflows/codex_review_trigger.yml
@@ -1,36 +1,63 @@
 name: Codex Review Trigger
 
 on:
-  workflow_run:
-    workflows: ["Test"]
-    types: [completed]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   request-codex-review:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
       issues: write
     concurrency:
-      group: codex-review-${{ github.event.workflow_run.id }}
+      group: codex-review-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
       cancel-in-progress: false
     steps:
       - name: Request Codex review on PR
         uses: actions/github-script@v7
         with:
           script: |
-            const run = context.payload.workflow_run;
-            const pr = run.pull_requests?.[0];
-            if (!pr) {
-              core.info('Skip posting: workflow_run has no associated pull request.');
-              return;
-            }
+            const pr = context.payload.pull_request;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const marker = `<!-- codex-review-trigger:workflow-run-id=${run.id} -->`;
+            const headSha = pr.head.sha;
+
+            const maxAttempts = 40; // 10 minutes with 15s interval
+            const waitMs = 15000;
+            let matchedRun = null;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: 'test.yml',
+                event: 'pull_request',
+                per_page: 100
+              });
+
+              matchedRun = runs.find((run) => run.head_sha === headSha);
+              if (matchedRun && matchedRun.status === 'completed') {
+                break;
+              }
+
+              core.info(`Waiting for Test workflow completion for sha=${headSha} (attempt ${attempt}/${maxAttempts})`);
+              await new Promise((resolve) => setTimeout(resolve, waitMs));
+            }
+
+            if (!matchedRun || matchedRun.status !== 'completed') {
+              core.setFailed(`Timed out waiting for Test workflow completion for sha=${headSha}`);
+              return;
+            }
+
+            if (matchedRun.conclusion !== 'success') {
+              core.info(`Skip posting: Test workflow conclusion is ${matchedRun.conclusion} for sha=${headSha}`);
+              return;
+            }
+
+            const marker = `<!-- codex-review-trigger:sha=${headSha} -->`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -41,7 +68,7 @@ jobs:
 
             const alreadyPosted = comments.some((comment) => comment.body && comment.body.includes(marker));
             if (alreadyPosted) {
-              core.info(`Skip posting: marker already exists for workflow_run.id=${run.id}`);
+              core.info(`Skip posting: marker already exists for sha=${headSha}`);
               return;
             }
 
@@ -49,8 +76,8 @@ jobs:
               '@codex review',
               '',
               'CI passed. Please review this PR update.',
-              `- Commit: \`${run.head_sha}\``,
-              `- Test run: ${run.html_url}`,
+              `- Commit: \`${headSha}\``,
+              `- Test run: ${matchedRun.html_url}`,
               '',
               marker
             ].join('\n');

--- a/.github/workflows/codex_review_trigger.yml
+++ b/.github/workflows/codex_review_trigger.yml
@@ -1,0 +1,63 @@
+name: Codex Review Trigger
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+
+jobs:
+  request-codex-review:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: codex-review-${{ github.event.workflow_run.id }}
+      cancel-in-progress: false
+    steps:
+      - name: Request Codex review on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const pr = run.pull_requests?.[0];
+            if (!pr) {
+              core.info('Skip posting: workflow_run has no associated pull request.');
+              return;
+            }
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = `<!-- codex-review-trigger:workflow-run-id=${run.id} -->`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100
+            });
+
+            const alreadyPosted = comments.some((comment) => comment.body && comment.body.includes(marker));
+            if (alreadyPosted) {
+              core.info(`Skip posting: marker already exists for workflow_run.id=${run.id}`);
+              return;
+            }
+
+            const body = [
+              '@codex review',
+              '',
+              'CI passed. Please review this PR update.',
+              `- Commit: \`${run.head_sha}\``,
+              `- Test run: ${run.html_url}`,
+              '',
+              marker
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body
+            });

--- a/.github/workflows/codex_review_trigger.yml
+++ b/.github/workflows/codex_review_trigger.yml
@@ -1,29 +1,51 @@
 name: Codex Review Trigger
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to comment on (for manual verification)"
+        required: false
+      head_sha:
+        description: "Head commit SHA to associate with this review request"
+        required: false
 
 jobs:
   request-codex-review:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read
       issues: write
+      pull-requests: write
     concurrency:
-      group: codex-review-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      group: codex-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.head.sha || inputs.head_sha }}
       cancel-in-progress: false
     steps:
       - name: Request Codex review on PR
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const headSha = pr.head.sha;
+            let prNumber;
+            let headSha;
+
+            if (context.eventName === 'workflow_dispatch') {
+              prNumber = Number(core.getInput('pr_number'));
+              headSha = core.getInput('head_sha')?.trim();
+              if (!prNumber || !headSha) {
+                core.setFailed('workflow_dispatch requires both inputs: pr_number and head_sha');
+                return;
+              }
+            } else {
+              const pr = context.payload.pull_request;
+              prNumber = pr.number;
+              headSha = pr.head.sha;
+            }
 
             const maxAttempts = 40; // 10 minutes with 15s interval
             const waitMs = 15000;
@@ -62,7 +84,7 @@ jobs:
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
-              issue_number: pr.number,
+              issue_number: prNumber,
               per_page: 100
             });
 
@@ -85,6 +107,6 @@ jobs:
             await github.rest.issues.createComment({
               owner,
               repo,
-              issue_number: pr.number,
+              issue_number: prNumber,
               body
             });

--- a/.github/workflows/codex_review_trigger.yml
+++ b/.github/workflows/codex_review_trigger.yml
@@ -79,34 +79,9 @@ jobs:
               return;
             }
 
-            const marker = `<!-- codex-review-trigger:sha=${headSha} -->`;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: prNumber,
-              per_page: 100
-            });
-
-            const alreadyPosted = comments.some((comment) => comment.body && comment.body.includes(marker));
-            if (alreadyPosted) {
-              core.info(`Skip posting: marker already exists for sha=${headSha}`);
-              return;
-            }
-
-            const body = [
-              '@codex review',
-              '',
-              'CI passed. Please review this PR update.',
-              `- Commit: \`${headSha}\``,
-              `- Test run: ${matchedRun.html_url}`,
-              '',
-              marker
-            ].join('\n');
-
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: prNumber,
-              body
+              body: '@codex review'
             });


### PR DESCRIPTION
## What
- add a dedicated workflow at `.github/workflows/codex_review_trigger.yml`
- trigger on successful completion of the existing `Test` workflow for pull_request events
- post `@codex review` comment to the target PR
- prevent duplicate posts for the same workflow run id while allowing re-posts on subsequent green runs

## Why
- automate Codex review requests after CI turns green
- support repeated review cycles on the same PR after additional commits

## How to verify
- open/update a PR and let `Test` pass
- confirm this workflow posts `@codex review` once per successful run
- re-push to the same PR, let CI pass again, and confirm a new trigger comment is posted
