### PR TITLE
Verify Ruby 4.0.1 compatibility in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-matrix:
+    name: test (${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -26,3 +27,14 @@ jobs:
         run: bundle exec rspec
       - name: Run RuboCop
         run: bundle exec rubocop
+
+  test:
+    runs-on: ubuntu-latest
+    needs: test-matrix
+    if: ${{ always() }}
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.test-matrix.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.3.0', '4.0.1']
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.0'
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: false
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ gem install nth_weekday
 ## 💻 Requirements / 動作環境
 
 - Ruby 3.3.0以上
+- CI verified on Ruby 3.3.0 and Ruby 4.0.1
 
 ## 🚀 Usage / 使い方
 

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -13,8 +13,15 @@ RSpec.describe 'project configuration' do
 
   it 'verifies compatibility on the minimum Ruby and Ruby 4.0.1 in CI' do
     workflow = YAML.load_file(File.join(root, '.github/workflows/test.yml'))
-    ruby_versions = workflow.fetch('jobs').fetch('test').fetch('strategy').fetch('matrix').fetch('ruby-version')
+    ruby_versions = workflow.fetch('jobs').fetch('test-matrix').fetch('strategy').fetch('matrix').fetch('ruby-version')
 
     expect(ruby_versions).to contain_exactly('3.3.0', '4.0.1')
+  end
+
+  it 'keeps the required test check available for branch protection' do
+    workflow = YAML.load_file(File.join(root, '.github/workflows/test.yml'))
+    test_job = workflow.fetch('jobs').fetch('test')
+
+    expect(test_job.fetch('needs')).to eq('test-matrix')
   end
 end

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+RSpec.describe 'project configuration' do
+  let(:root) { File.expand_path('..', __dir__) }
+
+  it 'keeps the minimum supported Ruby version at 3.3.0' do
+    gemspec = Gem::Specification.load(File.join(root, 'nth_weekday.gemspec'))
+
+    expect(gemspec.required_ruby_version).to eq(Gem::Requirement.new('>= 3.3.0'))
+  end
+
+  it 'verifies compatibility on the minimum Ruby and Ruby 4.0.1 in CI' do
+    workflow = YAML.load_file(File.join(root, '.github/workflows/test.yml'))
+    ruby_versions = workflow.fetch('jobs').fetch('test').fetch('strategy').fetch('matrix').fetch('ruby-version')
+
+    expect(ruby_versions).to contain_exactly('3.3.0', '4.0.1')
+  end
+end


### PR DESCRIPTION
## Summary

- Add a CI matrix for Ruby 3.3.0 and Ruby 4.0.1.
- Add project configuration specs that keep the minimum Ruby requirement at `>= 3.3.0` and assert the CI matrix covers Ruby 4.0.1.
- Preserve the required `test` check for branch protection by adding an aggregate job after the Ruby version matrix.
- Document the verified Ruby versions in the README without raising the minimum requirement.

## Related Issue

Closes #37

## Changes

- `.github/workflows/test.yml`: run RSpec and RuboCop on Ruby 3.3.0 and Ruby 4.0.1, then report the required aggregate `test` check.
- `spec/project_configuration_spec.rb`: cover the gemspec minimum Ruby requirement, CI Ruby matrix, and required check compatibility.
- `README.md`: state that CI verifies Ruby 3.3.0 and Ruby 4.0.1.

## Test Results

```text
bundle exec rake
14 examples, 0 failures

bundle exec rspec
15 examples, 0 failures

bundle exec rubocop
8 files inspected, no offenses detected

GitHub Actions Test #95
- test (3.3.0): success
- test (4.0.1): success
- test: success
```

## Documentation

README updated to distinguish the minimum Ruby requirement from verified CI versions.

## Notes

Ruby 4.0.1 is verified through GitHub Actions. The local runtime used for command verification was Ruby 3.3.5.

## Checklist

- [x] Tests pass
- [x] Documentation updated or not required
- [x] No unrelated changes
- [x] Review blockers resolved