### PR TITLE
Add date format option to NthWeekday.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added optional `format:` support to `NthWeekday.get` for `Date#strftime` strings and UTC midnight UNIX timestamps.
+
 ## [0.1.1] - 2025-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,16 +46,27 @@ NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3)
 # 最後の金曜日（2025年12月）
 NthWeekday.get(year: 2025, month: 12, weekday: :fr, nth: -1)
 # => #<Date: 2025-12-26>
+
+# 日付文字列として取得
+NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3, format: '%Y-%m-%d')
+# => "2025-04-16"
+
+# UNIXタイムスタンプとして取得（UTC 00:00:00基準）
+NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3, format: :unix)
+# => 1744761600
 ```
 
 ## 📘 Parameters / パラメータ
 
-| パラメータ名 | 型     | 説明                                                  |
-|--------------|--------|-------------------------------------------------------|
-| `year`       | Integer| 対象年（例: 2025）                                   |
-| `month`      | Integer| 対象月（1〜12）                                       |
-| `weekday`    | Symbol | 対象曜日（`:su`, `:mo`, `:tu`, `:we`, `:th`, `:fr`, `:sa`）      |
-| `nth`        | Integer| 第n◯曜日。1〜5、または `-1` で「最後の◯曜日」を指定 |
+| パラメータ名 | 型                    | 説明                                                  |
+|--------------|-----------------------|-------------------------------------------------------|
+| `year`       | Integer               | 対象年（例: 2025）                                   |
+| `month`      | Integer               | 対象月（1〜12）                                       |
+| `weekday`    | Symbol                | 対象曜日（`:su`, `:mo`, `:tu`, `:we`, `:th`, `:fr`, `:sa`）      |
+| `nth`        | Integer               | 第n◯曜日。1〜5、または `-1` で「最後の◯曜日」を指定 |
+| `format`     | String, Symbol, nil   | 省略可。`String` は `Date#strftime` 形式、`:unix` は UTC 00:00:00 基準の UNIX タイムスタンプ |
+
+`format` を省略した場合は、従来通り `Date` オブジェクトを返します。
 
 ### 曜日シンボル一覧
 - `:su` - 日曜日 (Sunday)

--- a/lib/nth_weekday.rb
+++ b/lib/nth_weekday.rb
@@ -21,10 +21,11 @@ module NthWeekday
     # @param month [Integer] Month (1-12)
     # @param weekday [Symbol] Weekday symbol (:mo, :tu, :we, :th, :fr, :sa, :su)
     # @param nth [Integer] The occurrence of the weekday (1-5, or -1 for last occurrence)
-    # @return [Date] Date object representing the requested day
+    # @param format [String, Symbol, nil] Optional output format. String uses Date#strftime, :unix returns UTC midnight timestamp.
+    # @return [Date, String, Integer, nil] Date object, formatted string, UNIX timestamp, or nil when no matching date exists
     # @raise [ArgumentError] If parameters are invalid
-    def get(year:, month:, weekday:, nth:)
-      validate_params(year, month, weekday, nth)
+    def get(year:, month:, weekday:, nth:, format: nil)
+      validate_params(year, month, weekday, nth, format)
 
       wday = WEEKDAY_MAP[weekday.to_sym]
       raise ArgumentError, 'Invalid weekday symbol' unless wday
@@ -34,19 +35,34 @@ module NthWeekday
 
       days = (first_day..last_day).select { |date| date.wday == wday }
 
-      if nth == -1
-        days.last
-      else
-        days[nth - 1]
-      end
+      date = if nth == -1
+               days.last
+             else
+               days[nth - 1]
+             end
+
+      format_date(date, format)
     end
 
     private
 
-    def validate_params(year, month, _weekday, nth)
+    def validate_params(year, month, _weekday, nth, format)
       raise ArgumentError, "Invalid year: #{year}" unless year.is_a?(Integer) && year.positive?
       raise ArgumentError, "Invalid month: #{month}" unless month.is_a?(Integer) && month.between?(1, 12)
       raise ArgumentError, "Invalid nth: #{nth}" unless nth.is_a?(Integer) && (nth.between?(1, 5) || nth == -1)
+      raise ArgumentError, "Invalid format: #{format}" unless valid_format?(format)
+    end
+
+    def valid_format?(format)
+      format.nil? || format.is_a?(String) || format == :unix
+    end
+
+    def format_date(date, format)
+      return nil if date.nil?
+      return date if format.nil?
+      return Time.utc(date.year, date.month, date.day).to_i if format == :unix
+
+      date.strftime(format)
     end
   end
 end

--- a/spec/nth_weekday_spec.rb
+++ b/spec/nth_weekday_spec.rb
@@ -35,6 +35,26 @@ RSpec.describe NthWeekday do
         result = NthWeekday.get(year: 2025, month: 2, weekday: :sa, nth: 5)
         expect(result).to be_nil
       end
+
+      it 'returns a formatted date string when format is a strftime pattern' do
+        result = NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3, format: '%Y-%m-%d')
+        expect(result).to eq('2025-04-16')
+      end
+
+      it 'returns a differently formatted date string when another strftime pattern is given' do
+        result = NthWeekday.get(year: 2025, month: 12, weekday: :fr, nth: -1, format: '%Y/%m/%d')
+        expect(result).to eq('2025/12/26')
+      end
+
+      it 'returns a UNIX timestamp at UTC midnight when format is unix' do
+        result = NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3, format: :unix)
+        expect(result).to eq(Time.utc(2025, 4, 16).to_i)
+      end
+
+      it 'returns nil with format when the nth occurrence does not exist in the month' do
+        result = NthWeekday.get(year: 2025, month: 2, weekday: :sa, nth: 5, format: '%Y-%m-%d')
+        expect(result).to be_nil
+      end
     end
 
     context 'with invalid parameters' do
@@ -66,6 +86,16 @@ RSpec.describe NthWeekday do
       it 'raises an error for negative nth other than -1' do
         expect { NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: -2) }
             .to raise_error(ArgumentError, 'Invalid nth: -2')
+      end
+
+      it 'raises an error for unsupported format symbols' do
+        expect { NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3, format: :timestamp) }
+            .to raise_error(ArgumentError, 'Invalid format: timestamp')
+      end
+
+      it 'raises an error for invalid format types' do
+        expect { NthWeekday.get(year: 2025, month: 4, weekday: :we, nth: 3, format: 123) }
+            .to raise_error(ArgumentError, 'Invalid format: 123')
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds an optional `format:` keyword to `NthWeekday.get` while preserving the existing default `Date` return value.

## Related Issue

Closes #40

## Changes

- Adds `format:` support for `Date#strftime`-compatible strings.
- Adds `format: :unix` support for UTC midnight UNIX timestamps.
- Preserves `nil` when the requested nth weekday does not exist.
- Documents the new option in README and CHANGELOG.

## Test Results

```text
bundle exec rspec
21 examples, 0 failures

bundle exec rubocop
8 files inspected, no offenses detected
```

## Documentation

README and CHANGELOG updated.

## Notes

- `format:` defaults to `nil`, so existing calls continue to return `Date`.
- `format: :unix` uses UTC 00:00:00 and returns epoch seconds.

## Checklist

- [x] Tests pass
- [x] Documentation updated or not required
- [x] No unrelated changes
- [x] Review blockers resolved